### PR TITLE
Add CI badges and fix stale gemspec URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ test/version_tmp
 Gemfile.lock
 .tool-versions
 .DS_Store
+.claude/
+mise.toml

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # OmniAuth::Oidc
 
+[![CI](https://github.com/CanalWestStudio/omniauth-oidc/actions/workflows/pull_request.yml/badge.svg)](https://github.com/CanalWestStudio/omniauth-oidc/actions/workflows/pull_request.yml)
+[![Gem Version](https://badge.fury.io/rb/omniauth-oidc.svg)](https://badge.fury.io/rb/omniauth-oidc)
+
 An OmniAuth strategy for OpenID Connect (OIDC) authentication. Supports multiple OIDC providers, PKCE, RP-Initiated Logout, and automatic discovery via the provider's configuration endpoint.
 
 Requires Ruby 3.1+.

--- a/omniauth-oidc.gemspec
+++ b/omniauth-oidc.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 3.1.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = "https://github.com/msuliq/omniauth-oidc"
+  spec.metadata["source_code_uri"] = "https://github.com/CanalWestStudio/omniauth-oidc"
   spec.metadata["changelog_uri"] = "https://github.com/CanalWestStudio/omniauth-oidc/blob/main/CHANGELOG.md"
 
   # Specify which files should be added to the gem when it is released.

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -20,7 +20,7 @@ class TestConfig < Minitest::Test
     assert_equal "#{ISSUER}/userinfo", config.userinfo_endpoint
     assert_equal "#{ISSUER}/jwks", config.jwks_uri
     assert_equal "#{ISSUER}/logout", config.end_session_endpoint
-    assert_equal ["openid", "email", "profile"], config.scopes_supported
+    assert_equal [ "openid", "email", "profile" ], config.scopes_supported
   end
 
   def test_fetch_handles_string_keys


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI badge and RubyGems version badge to README
- Fix `source_code_uri` in gemspec pointing to old upstream repo
- Rubocop autocorrect in test_config.rb