### PR TITLE
Add `oauth2_client` method for token refresh compatibility

### DIFF
--- a/lib/omniauth/strategies/oidc.rb
+++ b/lib/omniauth/strategies/oidc.rb
@@ -2,6 +2,7 @@
 
 require "base64"
 require "timeout"
+require "oauth2"
 require "omniauth"
 require "openid_connect"
 require "forwardable"
@@ -128,6 +129,19 @@ module OmniAuth
       # Initialize OpenIDConnect Client with options
       def client
         @client ||= ::OpenIDConnect::Client.new(client_options)
+      end
+
+      # Returns an OAuth2::Client (from the oauth2 gem) configured with the
+      # discovered token endpoint. Useful for token refresh flows where
+      # OAuth2::AccessToken requires an OAuth2::Client rather than the
+      # OpenIDConnect/Rack::OAuth2 client returned by #client.
+      def oauth2_client
+        @oauth2_client ||= ::OAuth2::Client.new(
+          client_options.identifier,
+          client_options.secret,
+          site: config.issuer,
+          token_url: config.token_endpoint
+        )
       end
 
       # Config is built from the JSON response from the OIDC config endpoint

--- a/omniauth-oidc.gemspec
+++ b/omniauth-oidc.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "faraday", "~> 2.0"
   spec.add_dependency "faraday-net_http_persistent", "~> 2.0"
   spec.add_dependency "faraday-retry", "~> 2.0"
+  spec.add_dependency "oauth2", ">= 1.4"
   spec.add_dependency "omniauth"
   spec.add_dependency "openid_connect"
 

--- a/test/test_strategy.rb
+++ b/test/test_strategy.rb
@@ -141,6 +141,32 @@ class TestStrategy < Minitest::Test
     assert_equal "my-id", client.identifier
   end
 
+  def test_oauth2_client_returns_oauth2_client
+    strategy = build_app(
+      client_options: {
+        identifier: "my-id",
+        secret: "my-secret"
+      }
+    )
+    stub_config_endpoint
+    init_strategy(strategy)
+
+    oauth2_client = strategy.oauth2_client
+
+    assert_instance_of OAuth2::Client, oauth2_client
+    assert_equal "my-id", oauth2_client.id
+    assert_equal "my-secret", oauth2_client.secret
+    assert_equal "#{ISSUER}/token", oauth2_client.token_url
+  end
+
+  def test_oauth2_client_is_memoized
+    strategy = build_app
+    stub_config_endpoint
+    init_strategy(strategy)
+
+    assert_same strategy.oauth2_client, strategy.oauth2_client
+  end
+
   def test_version_is_semver
     assert_match(/\A\d+\.\d+\.\d+\z/, OmniauthOidc::VERSION)
   end


### PR DESCRIPTION
## Add `oauth2_client` method for token refresh compatibility

### Problem

The OIDC strategy's `#client` method returns an `OpenIDConnect::Client` (which inherits from `Rack::OAuth2::Client`). Consumers that need to refresh OAuth tokens typically use `OAuth2::AccessToken` from the `oauth2` gem, which requires an `OAuth2::Client` — a completely different class from a different library. There's no way to get an `OAuth2::Client` from the strategy without manually extracting the credentials and token endpoint.

### Solution

Adds a public `#oauth2_client` method that returns an `OAuth2::Client` configured with the strategy's client credentials and discovered token endpoint. This bridges the two OAuth2 libraries.

### Usage

```ruby
strategy = OmniAuth::Strategies::Oidc.new(app, options)

# Existing — returns OpenIDConnect::Client (Rack::OAuth2)
strategy.client

# New — returns OAuth2::Client (oauth2 gem)
strategy.oauth2_client

# Token refresh example
token = OAuth2::AccessToken.new(
  strategy.oauth2_client,
  current_access_token,
  refresh_token: current_refresh_token
)
new_token = token.refresh!