### PR TITLE
Fix test ordering failures from Config cache pollution

### DIFF
--- a/test/test_callback.rb
+++ b/test/test_callback.rb
@@ -11,6 +11,7 @@ class TestCallback < Minitest::Test
     @nonce = "test-nonce"
     @id_token = generate_id_token(standard_id_token_claims(nonce: @nonce), @key)
     OmniAuth::Strategies::Oidc::Transport.reset!
+    OmniauthOidc::Config.clear_cache!
   end
 
   # --- Error handling ---

--- a/test/test_request.rb
+++ b/test/test_request.rb
@@ -7,6 +7,7 @@ class TestRequest < Minitest::Test
 
   def setup
     OmniAuth::Strategies::Oidc::Transport.reset!
+    OmniauthOidc::Config.clear_cache!
     stub_config_endpoint
   end
 

--- a/test/test_serializer.rb
+++ b/test/test_serializer.rb
@@ -7,6 +7,7 @@ class TestSerializer < Minitest::Test
 
   def setup
     OmniAuth::Strategies::Oidc::Transport.reset!
+    OmniauthOidc::Config.clear_cache!
   end
 
   def test_serialized_request_options_structure

--- a/test/test_strategy.rb
+++ b/test/test_strategy.rb
@@ -5,6 +5,11 @@ require "test_helper"
 class TestStrategy < Minitest::Test
   include OidcTestHelper
 
+  def setup
+    OmniAuth::Strategies::Oidc::Transport.reset!
+    OmniauthOidc::Config.clear_cache!
+  end
+
   def test_uid_field_defaults_to_sub
     strategy = build_app
     assert_equal "sub", strategy.options.uid_field

--- a/test/test_verify.rb
+++ b/test/test_verify.rb
@@ -9,6 +9,7 @@ class TestVerify < Minitest::Test
     @key, @jwk = generate_rsa_keypair
     @jwk_set = { keys: [ @jwk ] }
     OmniAuth::Strategies::Oidc::Transport.reset!
+    OmniauthOidc::Config.clear_cache!
   end
 
   def test_decode_id_token_with_rs256


### PR DESCRIPTION
## Problem

TestConfig tests like test_missing_optional_fields_are_nil cache a Config with nil fields. Other test classes never cleared the cache, so with certain seed orderings the stale partial config caused cascading failures: nil token_endpoint → "Invalid format of URI", nil jwks_uri → VerificationFailed, and nil id_token in session.

## Solution

Added OmniauthOidc::Config.clear_cache! to setup in all test classes.
