### PR TITLE
Update workflow to extract gem build/push to GPR

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,14 +37,16 @@ jobs:
           ruby-version: "3.3"
           bundler-cache: true
 
+      - name: Build gem
+        run: gem build *.gemspec
+
       - name: Publish to GPR
         run: |
           mkdir -p $HOME/.gem
           touch $HOME/.gem/credentials
           chmod 0600 $HOME/.gem/credentials
           printf -- "---\n:github: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
-          gem build *.gemspec
-          gem push --KEY github --host https://rubygems.pkg.github.com/${OWNER} *.gem
+          gem push --KEY github --host https://rubygems.pkg.github.com/${OWNER} *.gem || true
         env:
           GEM_HOST_API_KEY: "Bearer ${{secrets.GITHUB_TOKEN}}"
           OWNER: ${{ github.repository_owner }}
@@ -55,7 +57,6 @@ jobs:
           touch $HOME/.gem/credentials
           chmod 0600 $HOME/.gem/credentials
           printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
-          gem build *.gemspec
           gem push *.gem
         env:
           GEM_HOST_API_KEY: "${{secrets.RUBYGEMS_AUTH_TOKEN}}"

--- a/lib/omniauth/oidc/version.rb
+++ b/lib/omniauth/oidc/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OmniauthOidc
-  VERSION = "0.3.1"
+  VERSION = "0.3.2"
 end


### PR DESCRIPTION
Changes:

  1. Extracted gem build into its own step — builds once, both push steps use the same .gem file
  2. Added || true to the GPR push — a duplicate version on GPR won't block the RubyGems publish